### PR TITLE
Support MSVC target triples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,21 @@ documentation = "https://bozaro.github.io/daemon-rs/daemon/"
 libc = "*"
 
 [target.x86_64-pc-windows-gnu.dependencies]
-advapi32-sys = "*"
-kernel32-sys = "*"
-winapi = "*"
+advapi32-sys = "0.1"
+kernel32-sys = "0.1"
+winapi = "0.2"
 
 [target.i686-pc-windows-gnu.dependencies]
-advapi32-sys = "*"
-kernel32-sys = "*"
-winapi = "*"
+advapi32-sys = "0.1"
+kernel32-sys = "0.1"
+winapi = "0.2"
 
+[target.x86_64-pc-windows-msvc.dependencies]
+advapi32-sys = "0.1"
+kernel32-sys = "0.1"
+winapi = "0.2"
+
+[target.i686-pc-windows-msvc.dependencies]
+advapi32-sys = "0.1"
+kernel32-sys = "0.1"
+winapi = "0.2"


### PR DESCRIPTION
Also better specify dependency requirements
