### PR TITLE
Fix the build for windows with current version of rust and libs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,22 +10,6 @@ documentation = "https://bozaro.github.io/daemon-rs/daemon/"
 [dependencies]
 libc = "*"
 
-[target.x86_64-pc-windows-gnu.dependencies]
-advapi32-sys = "0.1"
-kernel32-sys = "0.1"
-winapi = "0.2"
-
-[target.i686-pc-windows-gnu.dependencies]
-advapi32-sys = "0.1"
-kernel32-sys = "0.1"
-winapi = "0.2"
-
-[target.x86_64-pc-windows-msvc.dependencies]
-advapi32-sys = "0.1"
-kernel32-sys = "0.1"
-winapi = "0.2"
-
-[target.i686-pc-windows-msvc.dependencies]
-advapi32-sys = "0.1"
-kernel32-sys = "0.1"
-winapi = "0.2"
+[target.'cfg(windows)'.dependencies]
+kernel32-sys = "0.2"
+winapi = { version = "0.3", features = [ "winsvc" ] }

--- a/src/bin/example.rs
+++ b/src/bin/example.rs
@@ -1,8 +1,8 @@
 extern crate daemon;
 
-use daemon::State;
 use daemon::Daemon;
 use daemon::DaemonRunner;
+use daemon::State;
 use std::env;
 use std::fs::OpenOptions;
 use std::io::Error;
@@ -10,35 +10,42 @@ use std::io::Write;
 use std::sync::mpsc::Receiver;
 
 fn main() {
-	log("Example started.");
-	let daemon = Daemon {
-		name: "example".to_string()
-	};
-	daemon.run(move |rx: Receiver<State>| {
-		log("Worker started.");
-		for signal in rx.iter() {
-			match signal {
-				State::Start => log("Worker: Start"),
-				State::Reload => log("Worker: Reload"),
-				State::Stop => log("Worker: Stop")
-			};
-		}
-		log("Worker finished.");
-	}).unwrap();
-	log("Example finished.");
+    log("Example started.");
+    let daemon = Daemon {
+        name: "example".to_string(),
+    };
+    daemon
+        .run(move |rx: Receiver<State>| {
+            log("Worker started.");
+            for signal in rx.iter() {
+                match signal {
+                    State::Start => log("Worker: Start"),
+                    State::Reload => log("Worker: Reload"),
+                    State::Stop => log("Worker: Stop"),
+                };
+            }
+            log("Worker finished.");
+        })
+        .unwrap();
+    log("Example finished.");
 }
-
 
 #[allow(unused_must_use)]
 fn log(message: &str) {
-	log_safe(message);
+    log_safe(message);
 }
 
 fn log_safe(message: &str) -> Result<(), Error> {
-	println! ("{}", message);
-	let path = try! (env::current_exe()).with_extension("log");
-	let mut file = try! (OpenOptions::new().create(true).write(true).append(true).open(&path));
-	try! (file.write(message.as_bytes()));
-	try! (file.write(b"\n"));
-	Ok(())
+    println!("{}", message);
+    let path = try!(env::current_exe()).with_extension("log");
+    let mut file = try!(
+        OpenOptions::new()
+            .create(true)
+            .write(true)
+            .append(true)
+            .open(&path)
+    );
+    try!(file.write(message.as_bytes()));
+    try!(file.write(b"\n"));
+    Ok(())
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,17 +1,17 @@
-use std::sync::mpsc::Receiver;
 use std::io::Error;
+use std::sync::mpsc::Receiver;
 
 pub enum State {
-	Start,
-	Reload,
-	Stop,
+    Start,
+    Reload,
+    Stop,
 }
 
 pub struct Daemon {
-	// Daemon name
-	pub name: String,
+    // Daemon name
+    pub name: String,
 }
 
 pub trait DaemonRunner {
-	fn run<F: 'static + FnOnce(Receiver<State>)>(&self, f: F) -> Result<(), Error>;
+    fn run<F: 'static + FnOnce(Receiver<State>)>(&self, f: F) -> Result<(), Error>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,8 @@
+#[cfg(target_os = "windows")]
+extern crate kernel32;
+#[cfg(target_os = "windows")]
+extern crate winapi;
+
 pub mod daemon;
 pub use daemon::*;
 

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -6,146 +6,140 @@ use std::sync::mpsc::channel;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
 
-declare_singleton! (singleton, DaemonHolder, DaemonHolder {holder: 0 as *mut DaemonStatic});
+declare_singleton!(
+    singleton,
+    DaemonHolder,
+    DaemonHolder {
+        holder: 0 as *mut DaemonStatic
+    }
+);
 
 struct DaemonHolder {
-	holder: *mut DaemonStatic,
+    holder: *mut DaemonStatic,
 }
 
-struct DaemonStatic
-{
-	holder: Box<DaemonFunc>,
+struct DaemonStatic {
+    holder: Box<DaemonFunc>,
 }
 
-trait DaemonFunc
-{
-	fn exec(&mut self) -> Result<(), Error>;
-	fn send(&mut self, state: State) -> Result<(), Error>;
-	fn take_tx(&mut self) -> Option<Sender<State>>;
+trait DaemonFunc {
+    fn exec(&mut self) -> Result<(), Error>;
+    fn send(&mut self, state: State) -> Result<(), Error>;
+    fn take_tx(&mut self) -> Option<Sender<State>>;
 }
 
-struct DaemonFuncHolder <F: FnOnce(Receiver<State>)>
-{
-	tx: Option<Sender<State>>,
-	func: Option<(F, Receiver<State>)>,
+struct DaemonFuncHolder<F: FnOnce(Receiver<State>)> {
+    tx: Option<Sender<State>>,
+    func: Option<(F, Receiver<State>)>,
 }
 
-impl <F: FnOnce(Receiver<State>)> DaemonFunc for DaemonFuncHolder<F>
-{
-	fn exec(&mut self) -> Result<(), Error>
-	{
-		match self.func.take()
-		{
-			Some((func, rx)) => {
-				func(rx);
-				Ok(())
-			}
-			None => Err(Error::new(ErrorKind::Other, "INTERNAL ERROR: Can't unwrap daemon function"))
-		}
-	}
+impl<F: FnOnce(Receiver<State>)> DaemonFunc for DaemonFuncHolder<F> {
+    fn exec(&mut self) -> Result<(), Error> {
+        match self.func.take() {
+            Some((func, rx)) => {
+                func(rx);
+                Ok(())
+            }
+            None => Err(Error::new(
+                ErrorKind::Other,
+                "INTERNAL ERROR: Can't unwrap daemon function",
+            )),
+        }
+    }
 
-	fn send(&mut self, state: State) -> Result<(), Error>
-	{
-		match self.tx
-		{
-			Some(ref tx) => match tx.send(state)
-			{
-				Ok(_) => Ok(()),
-				Err(e) => Err(Error::new(ErrorKind::Other, e)),
-			},
-			None => Err(Error::new(ErrorKind::Other, "Service is already exited")),
-		}
-	}
-	
-	fn take_tx(&mut self) -> Option<Sender<State>>
-	{
-		self.tx.take()
-	}
+    fn send(&mut self, state: State) -> Result<(), Error> {
+        match self.tx {
+            Some(ref tx) => match tx.send(state) {
+                Ok(_) => Ok(()),
+                Err(e) => Err(Error::new(ErrorKind::Other, e)),
+            },
+            None => Err(Error::new(ErrorKind::Other, "Service is already exited")),
+        }
+    }
+
+    fn take_tx(&mut self) -> Option<Sender<State>> {
+        self.tx.take()
+    }
 }
 
 fn daemon_wrapper<R, F: FnOnce(&mut DaemonHolder) -> R>(func: F) -> R {
-	let singleton = singleton();
-	let result = match singleton.lock() {
-		Ok(ref mut daemon) => {
-			func(daemon)
-		}
-		Err(e) => {
-			panic!("Mutex error: {:?}", e);
-		}
-	};
-	result
+    let singleton = singleton();
+    let result = match singleton.lock() {
+        Ok(ref mut daemon) => func(daemon),
+        Err(e) => {
+            panic!("Mutex error: {:?}", e);
+        }
+    };
+    result
 }
 
-impl DaemonRunner for Daemon
-{
-	fn run<F: 'static + FnOnce(Receiver<State>)>(&self, func: F) -> Result<(), Error> {
-		let (tx, rx) = channel();
-		tx.send(State::Start).unwrap();
-		let mut daemon = DaemonStatic
-		{
-			holder: Box::new(DaemonFuncHolder
-			{
-				tx: Some(tx),
-				func: Some((func, rx)),
-			}),
-		};
-		try! (guard_compare_and_swap(daemon_null(), &mut daemon));
-		let result = daemon_console(&mut daemon);
-		try! (guard_compare_and_swap(&mut daemon, daemon_null()));
-		result
-	}
+impl DaemonRunner for Daemon {
+    fn run<F: 'static + FnOnce(Receiver<State>)>(&self, func: F) -> Result<(), Error> {
+        let (tx, rx) = channel();
+        tx.send(State::Start).unwrap();
+        let mut daemon = DaemonStatic {
+            holder: Box::new(DaemonFuncHolder {
+                tx: Some(tx),
+                func: Some((func, rx)),
+            }),
+        };
+        try!(guard_compare_and_swap(daemon_null(), &mut daemon));
+        let result = daemon_console(&mut daemon);
+        try!(guard_compare_and_swap(&mut daemon, daemon_null()));
+        result
+    }
 }
 
-fn guard_compare_and_swap(old_value: *mut DaemonStatic, new_value: *mut DaemonStatic) -> Result<(), Error>
-{
-	daemon_wrapper(|daemon_static: &mut DaemonHolder| -> Result<(), Error> {
-		if daemon_static.holder != old_value
-		{
-			return Err(Error::new(ErrorKind::Other, "This function is not reentrant."));
-		}
-		daemon_static.holder = new_value;
-		Ok(())
-	})
+fn guard_compare_and_swap(
+    old_value: *mut DaemonStatic,
+    new_value: *mut DaemonStatic,
+) -> Result<(), Error> {
+    daemon_wrapper(|daemon_static: &mut DaemonHolder| -> Result<(), Error> {
+        if daemon_static.holder != old_value {
+            return Err(Error::new(
+                ErrorKind::Other,
+                "This function is not reentrant.",
+            ));
+        }
+        daemon_static.holder = new_value;
+        Ok(())
+    })
 }
 
-fn daemon_console(daemon: &mut DaemonStatic) -> Result<(), Error>
-{
-	let result;
-	unsafe
-	{
-		//if SetConsoleCtrlHandler(Some(console_handler), TRUE) == FALSE
-		//{
-		//	return Err(format! ("Failed SetConsoleCtrlHandler: {}", error_string(GetLastError() as i32)));
-		//}
-		result = daemon.holder.exec();
-		//if SetConsoleCtrlHandler(Some(console_handler), FALSE) == FALSE
-		//{
-		//	return Err(format! ("Failed SetConsoleCtrlHandler: {}", error_string(GetLastError() as i32)));
-		//}
-	}
-	result
+fn daemon_console(daemon: &mut DaemonStatic) -> Result<(), Error> {
+    let result;
+    unsafe {
+        //if SetConsoleCtrlHandler(Some(console_handler), TRUE) == FALSE
+        //{
+        //	return Err(format! ("Failed SetConsoleCtrlHandler: {}", error_string(GetLastError() as i32)));
+        //}
+        result = daemon.holder.exec();
+        //if SetConsoleCtrlHandler(Some(console_handler), FALSE) == FALSE
+        //{
+        //	return Err(format! ("Failed SetConsoleCtrlHandler: {}", error_string(GetLastError() as i32)));
+        //}
+    }
+    result
 }
 
-unsafe extern "system" fn signal_handler(sig: libc::c_int)
-{
-	daemon_wrapper(|daemon_static: &mut DaemonHolder| {
-		let daemon = &mut *daemon_static.holder;
-		return match daemon.holder.take_tx()
-		{
-			Some(ref tx) => {
-				let _ = tx.send(State::Stop);
-			}
-			None => ()
-		}
-	});
+unsafe extern "system" fn signal_handler(sig: libc::c_int) {
+    daemon_wrapper(|daemon_static: &mut DaemonHolder| {
+        let daemon = &mut *daemon_static.holder;
+        return match daemon.holder.take_tx() {
+            Some(ref tx) => {
+                let _ = tx.send(State::Stop);
+            }
+            None => (),
+        };
+    });
 }
 
 fn daemon_null() -> *mut DaemonStatic {
-	0 as *mut DaemonStatic
+    0 as *mut DaemonStatic
 }
 
 extern "C" {
-	fn raise(sig: libc::c_int) -> libc::c_int;
-	fn signal(sig: libc::c_int, handler: *const libc::c_void) -> libc::c_int;
-	fn kill(pid: libc::pid_t, sig: libc::c_int) -> libc::c_int;
+    fn raise(sig: libc::c_int) -> libc::c_int;
+    fn signal(sig: libc::c_int, handler: *const libc::c_void) -> libc::c_int;
+    fn kill(pid: libc::pid_t, sig: libc::c_int) -> libc::c_int;
 }

--- a/src/singleton.rs
+++ b/src/singleton.rs
@@ -1,83 +1,78 @@
-﻿#![macro_use]
-/** 
+#![macro_use]
+/**
  * Thanks for http://stackoverflow.com/questions/27791532/how-do-i-create-a-global-mutable-singleton
  */
-use std::sync::{Arc, Mutex, MutexGuard, LockResult};
+use std::sync::{Arc, LockResult, Mutex, MutexGuard};
 
 //#[derive(Copy)]
 pub struct SingletonHolder<T> {
-	// Since we will be used in many threads, we need to protect
-	// concurrent access
-	inner: Arc<Mutex<T>>,
+    // Since we will be used in many threads, we need to protect
+    // concurrent access
+    inner: Arc<Mutex<T>>,
 }
 
 impl<T> SingletonHolder<T> {
-	pub fn new(mutex: Arc<Mutex<T>>) -> SingletonHolder<T> {
-		SingletonHolder {
-			inner: mutex,
-		}
-	}
+    pub fn new(mutex: Arc<Mutex<T>>) -> SingletonHolder<T> {
+        SingletonHolder { inner: mutex }
+    }
 
-	pub fn lock(&self) -> LockResult<MutexGuard<T>> {
-		self.inner.lock()
-	}
+    pub fn lock(&self) -> LockResult<MutexGuard<T>> {
+        self.inner.lock()
+    }
 }
 
-impl <T> Clone for SingletonHolder<T> {
-	fn clone(&self) -> SingletonHolder<T> {
-		SingletonHolder {
-			inner: self.inner.clone(),
-		}
-	}
+impl<T> Clone for SingletonHolder<T> {
+    fn clone(&self) -> SingletonHolder<T> {
+        SingletonHolder {
+            inner: self.inner.clone(),
+        }
+    }
 }
 
 #[macro_export]
 macro_rules! declare_singleton {
-	(
-		$name: ident, // Function name
-		$t: ty, // Embedded type
-		$init: expr // Initial value
-	) => (
-		fn $name() -> $crate::singleton::SingletonHolder<$t> {
-			static mut SINGLETON: *const $crate::singleton::SingletonHolder<$t> = 0 as *const $crate::singleton::SingletonHolder<$t>;
-			static ONCE: ::std::sync::Once = ::std::sync::ONCE_INIT;
+    ($name:ident, $t:ty, $init:expr) => {
+        fn $name() -> $crate::singleton::SingletonHolder<$t> {
+            static mut SINGLETON: *const $crate::singleton::SingletonHolder<$t> =
+                0 as *const $crate::singleton::SingletonHolder<$t>;
+            static ONCE: ::std::sync::Once = ::std::sync::ONCE_INIT;
 
-			unsafe {
-				ONCE.call_once(|| {
-					let singleton = $crate::singleton::SingletonHolder::new(::std::sync::Arc::new(::std::sync::Mutex::new($init)));
-					
-					// Put it in the heap so it can outlive this call
-					SINGLETON = ::std::mem::transmute(Box::new(singleton));
+            unsafe {
+                ONCE.call_once(|| {
+                    let singleton = $crate::singleton::SingletonHolder::new(::std::sync::Arc::new(
+                        ::std::sync::Mutex::new($init),
+                    ));
 
-					// Make sure to free heap memory at exit
-					/* This doesn't exist in stable 1.0, so we will just leak it!
-					rt::at_exit(|| {
-						let singleton: Box<SingletonHolder> = mem::transmute(SINGLETON);
+                    // Put it in the heap so it can outlive this call
+                    SINGLETON = ::std::mem::transmute(Box::new(singleton));
 
-						// Let's explictly free the memory for this example
-						drop(singleton);
+                    // Make sure to free heap memory at exit
+        					/* This doesn't exist in stable 1.0, so we will just leak it!
+        					rt::at_exit(|| {
+        						let singleton: Box<SingletonHolder> = mem::transmute(SINGLETON);
 
-						// Set it to null again. I hope only one thread can call `at_exit`!
-						SINGLETON = 0 as *const _;
-					});
-					*/
-				});
-				(*SINGLETON).clone()
-			}
-		}
-	)
+        						// Let's explictly free the memory for this example
+        						drop(singleton);
+
+        						// Set it to null again. I hope only one thread can call `at_exit`!
+        						SINGLETON = 0 as *const _;
+        					});
+        					*/        });
+                (*SINGLETON).clone()
+            }
+        }
+    };
 }
-
 
 #[cfg(test)]
 mod test {
-	#[test]
-	fn smoke_test() {
-		declare_singleton!(simple_singleton, u32, 0);
-		let simple = simple_singleton();
-		match simple.lock() {
-			Ok(_) => {}
-			Err(_) => {}
-		};
-	}
+    #[test]
+    fn smoke_test() {
+        declare_singleton!(simple_singleton, u32, 0);
+        let simple = simple_singleton();
+        match simple.lock() {
+            Ok(_) => {}
+            Err(_) => {}
+        };
+    }
 }

--- a/src/singleton.rs
+++ b/src/singleton.rs
@@ -46,18 +46,8 @@ macro_rules! declare_singleton {
                     // Put it in the heap so it can outlive this call
                     SINGLETON = ::std::mem::transmute(Box::new(singleton));
 
-                    // Make sure to free heap memory at exit
-        					/* This doesn't exist in stable 1.0, so we will just leak it!
-        					rt::at_exit(|| {
-        						let singleton: Box<SingletonHolder> = mem::transmute(SINGLETON);
-
-        						// Let's explictly free the memory for this example
-        						drop(singleton);
-
-        						// Set it to null again. I hope only one thread can call `at_exit`!
-        						SINGLETON = 0 as *const _;
-        					});
-        					*/        });
+                    // TODO: Make sure to free heap memory at exit
+                });
                 (*SINGLETON).clone()
             }
         }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,244 +1,237 @@
-extern crate winapi;
 extern crate advapi32;
 extern crate kernel32;
+extern crate winapi;
 
+use self::advapi32::*;
+use self::kernel32::*;
+use self::winapi::*;
 use super::daemon::*;
 use std::io::{Error, ErrorKind};
+use std::ptr;
 use std::sync::mpsc::channel;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
-use std::ptr;
-use self::winapi::*;
-use self::advapi32::*;
-use self::kernel32::*;
 
-declare_singleton! (singleton, DaemonHolder, DaemonHolder {holder: 0 as *mut DaemonStatic});
+declare_singleton!(
+    singleton,
+    DaemonHolder,
+    DaemonHolder {
+        holder: 0 as *mut DaemonStatic
+    }
+);
 
 struct DaemonHolder {
-	holder: *mut DaemonStatic,
+    holder: *mut DaemonStatic,
 }
 
-struct DaemonStatic
-{
-	name: String,
-	holder: Box<DaemonFunc>,
-	handle: SERVICE_STATUS_HANDLE,
+struct DaemonStatic {
+    name: String,
+    holder: Box<DaemonFunc>,
+    handle: SERVICE_STATUS_HANDLE,
 }
 
-trait DaemonFunc
-{
-	fn exec(&mut self) -> Result<(), Error>;
-	fn send(&mut self, state: State) -> Result<(), Error>;
-	fn take_tx(&mut self) -> Option<Sender<State>>;
+trait DaemonFunc {
+    fn exec(&mut self) -> Result<(), Error>;
+    fn send(&mut self, state: State) -> Result<(), Error>;
+    fn take_tx(&mut self) -> Option<Sender<State>>;
 }
 
-struct DaemonFuncHolder <F: FnOnce(Receiver<State>)>
-{
-	tx: Option<Sender<State>>,
-	func: Option<(F, Receiver<State>)>,
+struct DaemonFuncHolder<F: FnOnce(Receiver<State>)> {
+    tx: Option<Sender<State>>,
+    func: Option<(F, Receiver<State>)>,
 }
 
+impl<F: FnOnce(Receiver<State>)> DaemonFunc for DaemonFuncHolder<F> {
+    fn exec(&mut self) -> Result<(), Error> {
+        match self.func.take() {
+            Some((func, rx)) => {
+                func(rx);
+                Ok(())
+            }
+            None => Err(Error::new(
+                ErrorKind::Other,
+                "INTERNAL ERROR: Can't unwrap daemon function",
+            )),
+        }
+    }
 
-impl <F: FnOnce(Receiver<State>)> DaemonFunc for DaemonFuncHolder<F>
-{
-	fn exec(&mut self) -> Result<(), Error>
-	{
-		match self.func.take()
-		{
-			Some((func, rx)) => {
-				func(rx);
-				Ok(())
-			}
-			None => Err(Error::new(ErrorKind::Other, "INTERNAL ERROR: Can't unwrap daemon function"))
-		}
-	}
+    fn send(&mut self, state: State) -> Result<(), Error> {
+        match self.tx {
+            Some(ref tx) => match tx.send(state) {
+                Ok(()) => Ok(()),
+                Err(e) => Err(Error::new(ErrorKind::Other, e)),
+            },
+            None => Err(Error::new(ErrorKind::Other, "Service is already exited")),
+        }
+    }
 
-	fn send(&mut self, state: State) -> Result<(), Error>
-	{
-		match self.tx
-		{
-			Some(ref tx) => match tx.send(state) {
-				Ok(()) => Ok(()),
-				Err(e) => Err(Error::new(ErrorKind::Other, e)),
-			},
-			None => Err(Error::new(ErrorKind::Other, "Service is already exited")),
-		}
-	}
-	
-	fn take_tx(&mut self) -> Option<Sender<State>>
-	{
-		self.tx.take()
-	}
+    fn take_tx(&mut self) -> Option<Sender<State>> {
+        self.tx.take()
+    }
 }
 
 fn daemon_wrapper<R, F: FnOnce(&mut DaemonHolder) -> R>(func: F) -> R {
-	let singleton = singleton();
-	let result = match singleton.lock() {
-		Ok(ref mut daemon) => {
-			func(daemon)
-		}
-		Err(e) => {
-			panic!("Mutex error: {:?}", e);
-		}
-	};
-	result
+    let singleton = singleton();
+    let result = match singleton.lock() {
+        Ok(ref mut daemon) => func(daemon),
+        Err(e) => {
+            panic!("Mutex error: {:?}", e);
+        }
+    };
+    result
 }
 
-impl DaemonRunner for Daemon
-{
-	fn run<F: 'static + FnOnce(Receiver<State>)>(&self, func: F) -> Result<(), Error> {
-		let (tx, rx) = channel();
-		tx.send(State::Start).unwrap();
-		let mut daemon = DaemonStatic
-		{
-			name: self.name.clone(),
-			holder: Box::new(DaemonFuncHolder
-			{
-				tx: Some(tx),
-				func: Some((func, rx)),
-			}),
-			handle: 0 as SERVICE_STATUS_HANDLE,
-		};
-		try! (guard_compare_and_swap(daemon_null(), &mut daemon));
-		let result = daemon_service(&mut daemon);
-		try! (guard_compare_and_swap(&mut daemon, daemon_null()));
-		result
-	}
+impl DaemonRunner for Daemon {
+    fn run<F: 'static + FnOnce(Receiver<State>)>(&self, func: F) -> Result<(), Error> {
+        let (tx, rx) = channel();
+        tx.send(State::Start).unwrap();
+        let mut daemon = DaemonStatic {
+            name: self.name.clone(),
+            holder: Box::new(DaemonFuncHolder {
+                tx: Some(tx),
+                func: Some((func, rx)),
+            }),
+            handle: 0 as SERVICE_STATUS_HANDLE,
+        };
+        try!(guard_compare_and_swap(daemon_null(), &mut daemon));
+        let result = daemon_service(&mut daemon);
+        try!(guard_compare_and_swap(&mut daemon, daemon_null()));
+        result
+    }
 }
 
-fn guard_compare_and_swap(old_value: *mut DaemonStatic, new_value: *mut DaemonStatic) -> Result<(), Error>
-{
-	daemon_wrapper(|daemon_static: &mut DaemonHolder| -> Result<(), Error> {
-		if daemon_static.holder != old_value
-		{
-			return Err(Error::new(ErrorKind::Other, "This function is not reentrant."));
-		}
-		daemon_static.holder = new_value;
-		Ok(())
-	})
+fn guard_compare_and_swap(
+    old_value: *mut DaemonStatic,
+    new_value: *mut DaemonStatic,
+) -> Result<(), Error> {
+    daemon_wrapper(|daemon_static: &mut DaemonHolder| -> Result<(), Error> {
+        if daemon_static.holder != old_value {
+            return Err(Error::new(
+                ErrorKind::Other,
+                "This function is not reentrant.",
+            ));
+        }
+        daemon_static.holder = new_value;
+        Ok(())
+    })
 }
 
-fn daemon_service(daemon: &mut DaemonStatic) -> Result<(), Error>
-{
-	unsafe
-	{
-		let service_name = service_name(&daemon.name);
-		let service_table: &[*const SERVICE_TABLE_ENTRYW] = &[
-			&SERVICE_TABLE_ENTRYW {
-				lpServiceName: service_name.as_ptr(),
-				lpServiceProc: Some(service_main),
-			},
-			ptr::null()
-		];
-		match StartServiceCtrlDispatcherW(*service_table.as_ptr())
-		{
-			0 => daemon_console(daemon),
-			_ => Ok(())
-		}
-	}
+fn daemon_service(daemon: &mut DaemonStatic) -> Result<(), Error> {
+    unsafe {
+        let service_name = service_name(&daemon.name);
+        let service_table: &[*const SERVICE_TABLE_ENTRYW] = &[
+            &SERVICE_TABLE_ENTRYW {
+                lpServiceName: service_name.as_ptr(),
+                lpServiceProc: Some(service_main),
+            },
+            ptr::null(),
+        ];
+        match StartServiceCtrlDispatcherW(*service_table.as_ptr()) {
+            0 => daemon_console(daemon),
+            _ => Ok(()),
+        }
+    }
 }
 
-fn daemon_console(daemon: &mut DaemonStatic) -> Result<(), Error>
-{
-	let result;
-	unsafe
-	{
-		if SetConsoleCtrlHandler(Some(console_handler), TRUE) == FALSE
-		{
-			return Err(Error::last_os_error());
-		}
-		result = daemon.holder.exec();
-		if SetConsoleCtrlHandler(Some(console_handler), FALSE) == FALSE
-		{
-			return Err(Error::last_os_error());
-		}
-	}
-	result
+fn daemon_console(daemon: &mut DaemonStatic) -> Result<(), Error> {
+    let result;
+    unsafe {
+        if SetConsoleCtrlHandler(Some(console_handler), TRUE) == FALSE {
+            return Err(Error::last_os_error());
+        }
+        result = daemon.holder.exec();
+        if SetConsoleCtrlHandler(Some(console_handler), FALSE) == FALSE {
+            return Err(Error::last_os_error());
+        }
+    }
+    result
 }
 
 fn service_name(name: &str) -> Vec<u16> {
-	let mut result: Vec<u16> = name.chars().map(|c| c as u16).collect();
-	result.push(0);
-	result
+    let mut result: Vec<u16> = name.chars().map(|c| c as u16).collect();
+    result.push(0);
+    result
 }
 
 fn create_service_status(current_state: DWORD) -> SERVICE_STATUS {
-	SERVICE_STATUS {
-		dwServiceType: SERVICE_WIN32_OWN_PROCESS,
-		dwCurrentState: current_state,
-		dwControlsAccepted: SERVICE_ACCEPT_STOP | SERVICE_ACCEPT_SHUTDOWN,
-		dwWin32ExitCode: 0,
-		dwServiceSpecificExitCode: 0,
-		dwCheckPoint: 0,
-		dwWaitHint: 0,
-	}
+    SERVICE_STATUS {
+        dwServiceType: SERVICE_WIN32_OWN_PROCESS,
+        dwCurrentState: current_state,
+        dwControlsAccepted: SERVICE_ACCEPT_STOP | SERVICE_ACCEPT_SHUTDOWN,
+        dwWin32ExitCode: 0,
+        dwServiceSpecificExitCode: 0,
+        dwCheckPoint: 0,
+        dwWaitHint: 0,
+    }
 }
 
 unsafe extern "system" fn service_main(
-	_: DWORD, // dw_num_services_args
-	_: *mut LPWSTR, // lp_service_arg_vectors
+    _: DWORD,       // dw_num_services_args
+    _: *mut LPWSTR, // lp_service_arg_vectors
 ) {
-	daemon_wrapper(|daemon_static: &mut DaemonHolder| {
-		if daemon_static.holder != daemon_null()
-		{
-			let daemon = &mut *daemon_static.holder;
-			let service_name = service_name(&daemon.name);
-			daemon.handle = RegisterServiceCtrlHandlerExW(service_name.as_ptr(), Some(service_handler), ptr::null_mut());
-			SetServiceStatus (daemon.handle, &mut create_service_status(SERVICE_START_PENDING));
-			SetServiceStatus (daemon.handle, &mut create_service_status(SERVICE_RUNNING));
+    daemon_wrapper(|daemon_static: &mut DaemonHolder| {
+        if daemon_static.holder != daemon_null() {
+            let daemon = &mut *daemon_static.holder;
+            let service_name = service_name(&daemon.name);
+            daemon.handle = RegisterServiceCtrlHandlerExW(
+                service_name.as_ptr(),
+                Some(service_handler),
+                ptr::null_mut(),
+            );
+            SetServiceStatus(
+                daemon.handle,
+                &mut create_service_status(SERVICE_START_PENDING),
+            );
+            SetServiceStatus(daemon.handle, &mut create_service_status(SERVICE_RUNNING));
 
-			daemon.holder.exec().unwrap();
-			SetServiceStatus (daemon.handle, &mut create_service_status(SERVICE_STOPPED));
-		}
-	});
+            daemon.holder.exec().unwrap();
+            SetServiceStatus(daemon.handle, &mut create_service_status(SERVICE_STOPPED));
+        }
+    });
 }
 
 unsafe extern "system" fn service_handler(
-	dw_control: DWORD,
-	_: DWORD,  // dw_event_type
-	_: LPVOID, // lp_event_data
-	_: LPVOID  // lp_context
+    dw_control: DWORD,
+    _: DWORD,  // dw_event_type
+    _: LPVOID, // lp_event_data
+    _: LPVOID, // lp_context
 ) -> DWORD {
-	daemon_wrapper(|daemon_static: &mut DaemonHolder| {
-		let daemon = &mut *daemon_static.holder;
-		match dw_control {
-			SERVICE_CONTROL_STOP | SERVICE_CONTROL_SHUTDOWN => {
-				match daemon.holder.take_tx()
-				{
-					Some(ref tx) => {
-						SetServiceStatus (daemon.handle, &mut create_service_status(SERVICE_STOP_PENDING));
-						let _ = tx.send(State::Stop);
-					}
-					None => {}
-				}
-			}
-			_ => {}
-		};
-	});
-	0
+    daemon_wrapper(|daemon_static: &mut DaemonHolder| {
+        let daemon = &mut *daemon_static.holder;
+        match dw_control {
+            SERVICE_CONTROL_STOP | SERVICE_CONTROL_SHUTDOWN => match daemon.holder.take_tx() {
+                Some(ref tx) => {
+                    SetServiceStatus(
+                        daemon.handle,
+                        &mut create_service_status(SERVICE_STOP_PENDING),
+                    );
+                    let _ = tx.send(State::Stop);
+                }
+                None => {}
+            },
+            _ => {}
+        };
+    });
+    0
 }
 
-unsafe extern "system" fn console_handler(_: DWORD) -> BOOL
-{
-	daemon_wrapper(|daemon_static: &mut DaemonHolder| -> BOOL {
-		if daemon_static.holder != daemon_null() {
-			let daemon = &mut *daemon_static.holder;
-			match daemon.holder.take_tx() {
-				Some(ref tx) => {
-					match tx.send(State::Stop)
-					{
-						Ok(_) => TRUE,
-						Err(_) => FALSE,
-					}
-				}
-				None => TRUE
-			}
-		} else {
-			FALSE
-		}
-	})
+unsafe extern "system" fn console_handler(_: DWORD) -> BOOL {
+    daemon_wrapper(|daemon_static: &mut DaemonHolder| -> BOOL {
+        if daemon_static.holder != daemon_null() {
+            let daemon = &mut *daemon_static.holder;
+            match daemon.holder.take_tx() {
+                Some(ref tx) => match tx.send(State::Stop) {
+                    Ok(_) => TRUE,
+                    Err(_) => FALSE,
+                },
+                None => TRUE,
+            }
+        } else {
+            FALSE
+        }
+    })
 }
 
 fn daemon_null() -> *mut DaemonStatic {
-	0 as *mut DaemonStatic
+    0 as *mut DaemonStatic
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,16 +1,15 @@
-extern crate advapi32;
-extern crate kernel32;
-extern crate winapi;
-
-use self::advapi32::*;
-use self::kernel32::*;
-use self::winapi::*;
 use super::daemon::*;
+
 use std::io::{Error, ErrorKind};
 use std::ptr;
 use std::sync::mpsc::channel;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
+
+use kernel32::*;
+use winapi::shared::minwindef::{BOOL, DWORD, FALSE, LPVOID, TRUE};
+use winapi::um::winnt::{SERVICE_WIN32_OWN_PROCESS, LPWSTR};
+use winapi::um::winsvc::*;
 
 declare_singleton!(
     singleton,


### PR DESCRIPTION
The `service_handler` function ended up in a mutex lock while the user
code was executing, so that no signal could be processed. This resulted
in a server reaction timeout in windows, which than killed the process.